### PR TITLE
refactor(*): use alpine package etcd

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM        alpine:edge
-RUN         apk  --no-cache --no-progress add ca-certificates openssl tar && \
-            wget https://github.com/coreos/etcd/releases/download/v3.0.10/etcd-v3.0.10-linux-amd64.tar.gz && \
-            tar xzvf etcd-v3.0.10-linux-amd64.tar.gz  && \
-            mv etcd-v3.0.10-linux-amd64/etcd* /bin/ && \
-            apk del --purge tar openssl && \
-            rm -Rf etcd-v3.0.10-linux-amd64* /var/cache/apk/*
+FROM        alpine:3.8
+ARG         ETCD_VERSION=3.3.9-r2
+RUN         echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories \
+            && apk --no-cache --no-progress add etcd=$ETCD_VERSION
 VOLUME      /data
 EXPOSE      2379 2380 4001 7001
-ADD         run.sh /bin/run.sh
+COPY        run.sh /bin/run.sh
 ENTRYPOINT  ["/bin/run.sh"]


### PR DESCRIPTION
Use alpine's provided package for installing etcd. Reduce image size down to 33 MB. Block alpine version.
